### PR TITLE
fix: token service was not registered using className definition

### DIFF
--- a/configuration/services.php
+++ b/configuration/services.php
@@ -31,12 +31,12 @@ if (isset($container)) {
         true // shared service
     );
 
-    // In your services.php file:
+    // Token service registration with className
     $container->set(
         'tokenService',
-        function () {
-            return new TokenService();
-        },
-        true
+        [
+            'className' => TokenService::class,
+            'shared' => true
+        ]
     );
 }


### PR DESCRIPTION
running the http test to register a user

```
### # @name Create Account POST 
{{maxmila.baseUrl}}/auth/register Content-Type: application/json 
{   "username": "toddsalpen@gmail.com",   "password": "*********" }
```

I get this new JSON with an Exception telling a Missing className  
```
 { "status": "error",   "code": 400,   "message": "Exception: Invalid service definition. Missing 'className' parameter" }
 ```
 
 **The Problem**
In your services.php file, you're registering the tokenService without properly specifying the 'className' parameter as required by Phalcon's DI container.